### PR TITLE
Update galactic devel_branch to match rosdistro source entry

### DIFF
--- a/tracks.yaml
+++ b/tracks.yaml
@@ -161,7 +161,7 @@ tracks:
       :{release_inc} --os-name fedora
     - git-bloom-generate -y rosrpm --prefix release/:{ros_distro} :{ros_distro} -i
       :{release_inc} --os-name rhel
-    devel_branch: master
+    devel_branch: galactic
     last_version: 0.9.1
     name: ament_cmake_ros
     patches: null


### PR DESCRIPTION
This PR from an automated script updates the devel_branch for galactic to match the source branch as specified in https://github.com/ros/rosdistro/galactic/distribution.yaml .
